### PR TITLE
Add Docker deployment setup

### DIFF
--- a/.env
+++ b/.env
@@ -3,4 +3,5 @@ GITHUB_CLIENT_ID=Ov23liQwUC26P0wfpo5E
 GITHUB_CLIENT_SECRET=7c0fb629645b8a4e839c8acca0152c15393801c3
 GITHUB_CALLBACK_URL=http://localhost:3123/auth/github/callback
 ENVIRONMENT=development
-REDIS_URL=redis://localhost:6379
+REDIS_PORT=6380
+REDIS_URL=redis://localhost:${REDIS_PORT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# TerrainForge3D Dockerfile
+FROM node:22-slim
+
+WORKDIR /app
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-venv python3-dev python3-pip \
+    gdal-bin libgdal-dev \
+    openscad \
+    build-essential \
+    curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Application user
+RUN groupadd -r appuser && useradd -r -g appuser -d /app -s /sbin/nologin appuser
+
+# Python virtualenv
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install Node dependencies
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Copy application code
+COPY . .
+RUN mkdir -p uploads outputs temp database && chown -R appuser:appuser /app
+
+# Entry point
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh /app/scripts/fix-permissions.sh
+USER appuser
+
+EXPOSE 3000
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -170,6 +170,28 @@ Run the test suite:
 node test-job-system.js
 ```
 
+## Docker Deployment
+
+The project includes a Docker setup for running the service and a Redis instance.
+To build and run everything with Docker:
+
+```bash
+docker-compose up -d --build
+```
+
+Volume permissions can be corrected by running:
+
+```bash
+docker compose exec app /app/scripts/fix-permissions.sh
+```
+
+The Redis service listens on the port specified by `REDIS_PORT` in the `.env`
+file. The Node.js application will use the `REDIS_URL` variable defined there.
+
+The Dockerfile installs OpenSCAD via apt which provides the `Manifold` backend
+needed for fast STL generation. Verify that the installed version is 2021.01 or
+newer when deploying on your own base image.
+
 ## Future Enhancements
 
 - [ ] Authentication system for user management

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,34 @@
+version: "3"
+
 services:
   app:
-    build: .
+    build:
+      context: .
+      args:
+        - NODE_ENV=production
     env_file:
       - .env
+    environment:
+      - NODE_ENV=production
     ports:
       - "${PORT}:${PORT}"
     volumes:
       - ./uploads:/app/uploads
       - ./outputs:/app/outputs
+      - ./temp:/app/temp
+      - ./database:/app/database
+    restart: unless-stopped
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7-alpine
+    command: redis-server --port ${REDIS_PORT}
+    ports:
+      - "${REDIS_PORT}:${REDIS_PORT}"
+    volumes:
+      - redis_data:/data
+    restart: unless-stopped
+
+volumes:
+  redis_data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -e
+/app/scripts/fix-permissions.sh
+exec "$@"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Core dependencies
-shapely>=2.0.0
-geopandas>=0.14.0  # For geospatial data manipulation and clipping
+shapely>=2.1.0
+geopandas>=0.14.2  # For geospatial data manipulation and clipping
 requests>=2.31.0  # For API calls
 pyproj>=3.6.0  # For coordinate transformations
 

--- a/scripts/fix-permissions.sh
+++ b/scripts/fix-permissions.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+# Adjust ownership and permissions for mounted volumes
+set -e
+
+TARGET_UID=${APP_UID:-1000}
+TARGET_GID=${APP_GID:-1000}
+
+chown -R $TARGET_UID:$TARGET_GID /app/uploads /app/outputs /app/temp /app/database 2>/dev/null || true
+find /app/uploads /app/outputs /app/temp /app/database -type d -exec chmod 775 {} +
+find /app/uploads /app/outputs /app/temp /app/database -type f -exec chmod 664 {} +


### PR DESCRIPTION
## Summary
- add Dockerfile using Node 22 with OpenSCAD
- include docker-compose with Redis service on configurable port
- adjust volume permissions with new script
- update requirements to newer shapely and geopandas
- document Docker usage
- update `.env` with `REDIS_PORT`

## Testing
- `python test_osm_fetch.py` *(fails: Tunnel connection failed)*
- `python test_relations.py` *(fails: Tunnel connection failed)*
- `python test_water_features.py` *(fails: Tunnel connection failed)*


------
https://chatgpt.com/codex/tasks/task_b_683f44843e34832f8e9a95dd46a9196d